### PR TITLE
Generate DAI from truffle initial migration

### DIFF
--- a/contracts/DssDeploy.sol
+++ b/contracts/DssDeploy.sol
@@ -225,6 +225,7 @@ contract DssDeploy {
 
         // Internal auth
         vat.rely(address(spotter));
+        vat.rely(msg.sender); // Keydonix added this, to allow direct 'flip' (parameter updates)
     }
 
     function deployDai(uint256 chainId) public {

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -23,6 +23,35 @@ module.exports = async function (deployer, network, [account]) {
 			dssDeploy.pot(),
 			dssDeploy.daiJoin()
 		])
+
+	// const wethToken = await deployer.deploy(artifacts.require('WETH9_'), web3.utils.asciiToHex('MKR'))
+	const ethJoin = await deployer.deploy(artifacts.require('ETHJoin'), vatAddress, web3.utils.asciiToHex('ETH-A'))
+	const priceFeed = await deployer.deploy(artifacts.require('DSValue'))
+	await priceFeed.poke('0x' + web3.utils.toWei("2", "ether"));
+	await dssDeploy.deployCollateral(web3.utils.asciiToHex("ETH-A"), ethJoin.address, priceFeed.address)
+	await ethJoin.join(account, { value: web3.utils.toWei("2", "ether")} )
+	// let newVar = await ethJoin.exit(account, 11);
+	// console.log("exit", newVar)
+	const vatContract = await artifacts.require('Vat').at(vatAddress);
+	const daiContract = await artifacts.require('Dai').at(daiAddress);
+	const daiJoinContract = await artifacts.require('DaiJoin').at(daiJoinAddress);
+	await vatContract.file(web3.utils.asciiToHex("ETH-A"), web3.utils.asciiToHex("line"), "0x99999999999999999999999999999999999999999999999")
+	await vatContract.file(web3.utils.asciiToHex("ETH-A"), web3.utils.asciiToHex("spot"), "0x99999999999999999999999999999999999999999999999")
+	await vatContract.file(web3.utils.asciiToHex("Line"), "0x99999999999999999999999999999999999999999999999")
+	console.log("about to frob")
+	console.log(await vatContract.gem(web3.utils.asciiToHex("ETH-A"), account))
+	console.log(await vatContract.dai(account))
+	let frob = await vatContract.frob(web3.utils.asciiToHex("ETH-A"), account, account, account, web3.utils.toWei("1", "ether"), web3.utils.toWei("1", "ether"));
+	console.log("frob", frob);
+	console.log(await vatContract.gem(web3.utils.asciiToHex("ETH-A"), account))
+	console.log(await vatContract.dai(account))
+
+	await vatContract.hope(daiJoinAddress);
+
+	console.log(await daiContract.balanceOf(account))
+	await daiJoinContract.exit(account, 44)
+	console.log(await daiContract.balanceOf(account))
+
 	const uniswapFactoryContract = await deployUniswapFactory(deployer)
 	// await dssDeploy.deployCollateral
 	// await dssDeploy.releaseAuth

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -84,33 +84,23 @@ async function deployErc1820(account) {
 }
 
 async function deployDssDeploy(deployer) {
-	const vatFab     = await deployer.deploy(artifacts.require('VatFab'))
-	const jugFab     = await deployer.deploy(artifacts.require('JugFab'))
-	const vowFab     = await deployer.deploy(artifacts.require('VowFab'))
-	const catFab     = await deployer.deploy(artifacts.require('CatFab'))
-	const daiFab     = await deployer.deploy(artifacts.require('DaiFab'))
-	const daiJoinFab = await deployer.deploy(artifacts.require('DaiJoinFab'))
-	const flapFab     = await deployer.deploy(artifacts.require('FlapFab'))
-	const flopFab     = await deployer.deploy(artifacts.require('FlopFab'))
-	const flipFab     = await deployer.deploy(artifacts.require('FlipFab'))
-	const spotFab    = await deployer.deploy(artifacts.require('SpotFab'))
-	const potFab     = await deployer.deploy(artifacts.require('PotFab'))
-	const endFab     = await deployer.deploy(artifacts.require('EndFab'))
-	const esmFab     = await deployer.deploy(artifacts.require('ESMFab'))
+	const fabs = [
+		'VatFab',
+		'JugFab',
+		'VowFab',
+		'CatFab',
+		'DaiFab',
+		'DaiJoinFab',
+		'FlapFab',
+		'FlopFab',
+		'FlipFab',
+		'SpotFab',
+		'PotFab',
+		'EndFab',
+		'ESMFab']
+	const fabContracts = await Promise.all(fabs.map(fab => deployer.deploy(artifacts.require(fab))))
 	return deployer.deploy(artifacts.require('DssDeploy'),
-		vatFab.address,
-		jugFab.address,
-		vowFab.address,
-		catFab.address,
-		daiFab.address,
-		daiJoinFab.address,
-		flapFab.address,
-		flopFab.address,
-		flipFab.address,
-		spotFab.address,
-		potFab.address,
-		endFab.address,
-		esmFab.address,
+		...fabContracts.map(fab => fab.address)
 	)
 }
 


### PR DESCRIPTION
Not pretty, but it works.

- I have some extra logging in there, at least for now around balance printing, because it helps me understand some of the mechanics (especially the vat dai units!)
- Ran out of reasonable units for web3.utils.toWei , should probably start using a real BN library. Debt Ceiling is tracked in ether-gether's
- Price feed is fixed, not using an actual DS-Value or medianizer (but can be updated by a call to file(spot)

Haven't worked on repaying the DAI yet, will require setting some stability fees and minting some of the mkrToken.

Seems like it could go into a few Truffle phases, in a perfect world.