### PR TITLE
Create report for variable gas usage when updating drip and fetching chi

### DIFF
--- a/test/test-dependencies.ts
+++ b/test/test-dependencies.ts
@@ -43,6 +43,7 @@ function getGasLimit(methodSignature: string): {gasLimit?: bigint} {
 }
 
 const explicitGasPrices: Record<string, bigint> = {
+	'drip()': 100000n,
 	'deposit(uint256)': 300000n,
 	'withdrawVatDai(address,uint256)': 200000n,
 	'withdrawToDenominatedInDai(address,uint256)': 300000n,

--- a/test/test.ts
+++ b/test/test.ts
@@ -245,13 +245,15 @@ describe('DaiHrd', () => {
 	})
 
 	// This requires changing DaiHrd.updateAndFetchChi() from private to public
-	xit('chi variable gas usage report', async () => {
-		const MINUTES_TO_CHECK = [
+	fit('chi variable gas usage report', async () => {
+		const SECONDS_TO_CHECK = [
 			1,
-			60,
-			60*24,
-			60*24*365,
-			60*24*365 * 10,
+			60 * 60,
+			60 * 60 * 24,
+			60 * 60 * 24 * 365,
+			60 * 60 * 24 * 365 * 10,
+			0b1111111111111111111111111, // 33_554_431 ~ 1 year
+			0b1111111111111111111111111111, // 268,435,455 ~ 10 year
 		]
 		const attodaiToDeposit = daiToAttodai(10_000n)
 		await generateDai(alice, attodaiToDeposit)
@@ -281,26 +283,26 @@ describe('DaiHrd', () => {
 			data: await encodeMethod(keccak256.hash, 'updateAndFetchChi()', []),
 		}
 
-		async function printEstimatesByMinute(tx: IOffChainTransaction) {
+		async function printEstimatesBySecond(tx: IOffChainTransaction) {
 			const results: Array<[number, bigint]> = []
 			await alice.pot.drip();
 			results.push([0, await alice.rpc.estimateGas(tx)])
-			for (const minute of MINUTES_TO_CHECK) {
+			for (const seconds of SECONDS_TO_CHECK) {
 				await alice.pot.drip();
-				await ganache.advanceTime(minute * 60)
-				results.push([minute, await alice.rpc.estimateGas(tx)])
+				await ganache.advanceTime(seconds)
+				results.push([seconds, await alice.rpc.estimateGas(tx)])
 			}
-			results.forEach(report => console.log(`${report[1]} gas : ${report[0]} minutes`))
+			results.forEach(report => console.log(`${report[1]} gas : ${report[0]} seconds`))
 		}
 
 		console.log("withdrawTo()")
-		await printEstimatesByMinute(withdrawToEstimate)
+		await printEstimatesBySecond(withdrawToEstimate)
 
 		console.log("\ncalculateChi()")
-		await printEstimatesByMinute(calculatedChiEstimate);
+		await printEstimatesBySecond(calculatedChiEstimate);
 
 		console.log("\nupdateAndFetchChi()")
-		await printEstimatesByMinute(updateAndFetchChiEstimate);
+		await printEstimatesBySecond(updateAndFetchChiEstimate);
 
 	})
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -266,17 +266,22 @@ describe('DaiHrd', () => {
 			gasPrice: 1000000000n
 		};
 
-		const updateAndFetchChiEstimate = {
+		const withdrawToEstimate = {
 			...baseEstimateTx,
-			data: await encodeMethod(keccak256.hash, 'updateAndFetchChi()', []),
-		}
+			data: await encodeMethod(keccak256.hash, 'withdrawTo(address,uint256)', [alice.address, daiToAttodai(1)]),
+		};
 
 		const calculatedChiEstimate = {
 			...baseEstimateTx,
 			data: await encodeMethod(keccak256.hash, 'calculatedChi()', []),
 		};
 
-		async function gasEstimatesByMinute(tx: IOffChainTransaction) {
+		const updateAndFetchChiEstimate = {
+			...baseEstimateTx,
+			data: await encodeMethod(keccak256.hash, 'updateAndFetchChi()', []),
+		}
+
+		async function printEstimatesByMinute(tx: IOffChainTransaction) {
 			const results: Array<[number, bigint]> = []
 			await alice.pot.drip();
 			results.push([0, await alice.rpc.estimateGas(tx)])
@@ -285,16 +290,18 @@ describe('DaiHrd', () => {
 				await ganache.advanceTime(minute * 60)
 				results.push([minute, await alice.rpc.estimateGas(tx)])
 			}
-			return results;
+			results.forEach(report => console.log(`${report[1]} gas : ${report[0]} minutes`))
 		}
 
-		const updateAndFetchResults = await gasEstimatesByMinute(updateAndFetchChiEstimate);
-		console.log("updateAndFetchChi()")
-		updateAndFetchResults.forEach(report => console.log(`${report[1]} gas : ${report[0]} minutes`))
+		console.log("withdrawTo()")
+		await printEstimatesByMinute(withdrawToEstimate)
 
-		const calculateChiResults = await gasEstimatesByMinute(calculatedChiEstimate);
 		console.log("\ncalculateChi()")
-		calculateChiResults.forEach(report => console.log(`${report[1]} gas : ${report[0]} minutes`))
+		await printEstimatesByMinute(calculatedChiEstimate);
+
+		console.log("\nupdateAndFetchChi()")
+		await printEstimatesByMinute(updateAndFetchChiEstimate);
+
 	})
 
 	xit('estimateGas', async () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -15,7 +15,7 @@ import { Actor, duplicateActor } from '../scripts/libraries/actor';
 import { TestDependencies } from './test-dependencies';
 import { generateDai } from '../scripts/seed/seed-maker';
 import { resetMaker } from '../scripts/seed/reset-maker';
-import { IOffChainTransaction } from "@zoltu/ethereum-types/output-node";
+import { IOffChainTransaction } from "@zoltu/ethereum-types";
 
 const MAX_APPROVAL = 2n**256n-1n
 


### PR DESCRIPTION
If we went with 1 year, any request that
 - contains "updateAndFetchChi" = +50,340
 - contains calcualteChi = +5,258 
 - is withdrawTo = 51,771

All the values below include the base transaction cost, but since we're only looking for difference between cached and non-cached run, base cost cancels out

There is one odd case, withdrawTo, where it does a now-protected drip, but doesn't fetch chi if rho == now. It's the only case where we want to drip, but don't need chi, so it's delta will be slightly larger

```
withdrawTo()
216102 gas : 0 minutes
263927 gas : 1 minutes
264959 gas : 60 minutes
265932 gas : 1440 minutes
267873 gas : 525600 minutes
268345 gas : 5256000 minutes

updateAndFetchChi()
25781 gas : 0 minutes
72112 gas : 1 minutes
73160 gas : 60 minutes
74149 gas : 1440 minutes
76121 gas : 525600 minutes
76590 gas : 5256000 minutes

calculateChi()
28208 gas : 0 minutes
29520 gas : 1 minutes
30552 gas : 60 minutes
31525 gas : 1440 minutes
33466 gas : 525600 minutes
33928 gas : 5256000 minutes
```