### PR TITLE
Increases min-height of Uniswap iframe to remove scrollbars.

### DIFF
--- a/dapp/app/ts/components/App.tsx
+++ b/dapp/app/ts/components/App.tsx
@@ -62,7 +62,7 @@ export function App(model: Readonly<AppModel>) {
 			</section>
 		</>}
 		<div style={{ height: '15px', flexShrink: 0 }}></div>
-		<iframe style={{ width: '615px', minHeight: '768px', border: 'none', borderRadius: '4px' }} src='https://uniswap.exchange/swap?outputCurrency=0x9B869c2eaae08136C43d824EA75A2F376f1aA983'></iframe>
+		<iframe style={{ width: '615px', minHeight: '915px', border: 'none', borderRadius: '4px' }} src='https://uniswap.exchange/swap?outputCurrency=0x9B869c2eaae08136C43d824EA75A2F376f1aA983'></iframe>
 		<div style={{ flexGrow: 1 }}></div>
 		<nav style={{ display: 'flex', flexDirection: 'row', padding: '15px' }}>
 			<a href='https://discord.gg/b88nb2S'>


### PR DESCRIPTION
I think Uniswap changed something on their end, as we now have scrollbars.  This fix just increases the min height to get rid of them.

Unfortunately, there is no way to auto-size an iframe correctly without the UI helping out, and in this case the Uniswap UI doesn't help out.

I probably won't push this change, as we don't have CI/CD and it is a bit of a pain to go through all of the motions of pushing, but I wanted to get it included in case we push for some other reason (or someone convinces me to push it).